### PR TITLE
Enable UTF-8 JSON file generation

### DIFF
--- a/src/Command/Translator.php
+++ b/src/Command/Translator.php
@@ -131,7 +131,7 @@ class Translator extends Command
      */
     private function writeNewTranslationFile($filePath, $translations)
     {
-        file_put_contents($filePath, json_encode($translations, JSON_PRETTY_PRINT));
+        file_put_contents($filePath, json_encode($translations, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE));
     }
 
     /**


### PR DESCRIPTION
Hi,

thanks for your package!

I run into the issue where my German charcters (öäüß) got encoded into their hexadecimal representation. This is a bit confusing for further changes at the localization and so I have added the json_encode option for unescaped unicode.