### PR TITLE
Fix strings with escaped quotes

### DIFF
--- a/src/Translator/TranslationScanner.php
+++ b/src/Translator/TranslationScanner.php
@@ -59,11 +59,13 @@ class TranslationScanner
         $matches = $matches[1] ?? [];
 
         return array_reduce($matches, function (array $keys, string $match) {
-            preg_match('#\'(.*?)\'#', str_replace('"', "'", $match), $matchKey);
+            preg_match("#(['\"])((?:\\\\\\1|.)*?)\\1#", $match, $matchKey);
 
-            $key = $matchKey[1] ?? '';
+            $key = $matchKey[2] ?? '';
 
-            return array_merge($keys, [$key => new Translation($key, '')]);
+            return $key ?
+                array_merge($keys, [$key => new Translation($key, '')]) :
+                $keys;
         }, []);
     }
 }

--- a/tests/Fixtures/App/View/index.blade.php
+++ b/tests/Fixtures/App/View/index.blade.php
@@ -14,5 +14,17 @@
         <div>
             {{ __('Check offers to :planet', [':place' => 'Damogran']) }}
         </div>
+
+        <div>
+            {{ __("Translations should also work with double quotes.") }}
+        </div>
+
+        <div>
+            {{ __('Shouldn\'t escaped quotes within strings also be correctly added?') }}
+        </div>
+
+        <div>
+            {{ __("Same goes for \"double quotes\".") }}
+        </div>
     </body>
 </html>

--- a/tests/Unit/Framework/HelperTest.php
+++ b/tests/Unit/Framework/HelperTest.php
@@ -27,7 +27,7 @@ class HelperTest extends TestCase
             '/Fixtures/Glob/SubDir/SubDirFile2.txt',
             '/Fixtures/Glob/SubDir/SubDir2/SubDir2file1.txt',
             '/Fixtures/Glob/SubDir/SubDir2/SubDir2file2.txt',
-        ], $this->removeRelativePath($files));
+        ], $this->replaceDirectorySeparators($this->removeRelativePath($files)));
     }
 
     /**
@@ -38,6 +38,17 @@ class HelperTest extends TestCase
     {
         return array_map(function (string $file): string {
             return str_replace($this->testDir, '', $file);
+        }, $files);
+    }
+
+    /**
+     * @param string[] $files
+     * @return string[]
+     */
+    private function replaceDirectorySeparators(array $files): array
+    {
+        return array_map(function (string $file): string {
+            return str_replace('\\', '/', $file);
         }, $files);
     }
 }

--- a/tests/Unit/Translator/TranslationScannerTest.php
+++ b/tests/Unit/Translator/TranslationScannerTest.php
@@ -69,6 +69,15 @@ class TranslationScannerTest extends TestCase
                 'Welcome, :name' => new Translation('Welcome, :name', ''),
                 'Trip to :planet, check-in opens :time' => new Translation('Trip to :planet, check-in opens :time', ''),
                 'Check offers to :planet' => new Translation('Check offers to :planet', ''),
+                'Translations should also work with double quotes.' => new Translation(
+                    'Translations should also work with double quotes.',
+                    ''
+                ),
+                'Shouldn\\\'t escaped quotes within strings also be correctly added?' => new Translation(
+                    'Shouldn\\\'t escaped quotes within strings also be correctly added?',
+                    ''
+                ),
+                'Same goes for \"double quotes\".' => new Translation('Same goes for \"double quotes\".', ''),
             ],
             $translations
         );
@@ -85,6 +94,15 @@ class TranslationScannerTest extends TestCase
                 'Welcome, :name' => new Translation('Welcome, :name', ''),
                 'Trip to :planet, check-in opens :time' => new Translation('Trip to :planet, check-in opens :time', ''),
                 'Check offers to :planet' => new Translation('Check offers to :planet', ''),
+                'Translations should also work with double quotes.' => new Translation(
+                    'Translations should also work with double quotes.',
+                    ''
+                ),
+                'Shouldn\\\'t escaped quotes within strings also be correctly added?' => new Translation(
+                    'Shouldn\\\'t escaped quotes within strings also be correctly added?',
+                    ''
+                ),
+                'Same goes for \"double quotes\".' => new Translation('Same goes for \"double quotes\".', ''),
                 'Underscore: :foo, :bar' => new Translation('Underscore: :foo, :bar', ''),
                 'Lang: :foo, :bar' => new Translation('Lang: :foo, :bar', ''),
             ],

--- a/tests/Unit/Translator/TranslationServiceTest.php
+++ b/tests/Unit/Translator/TranslationServiceTest.php
@@ -52,10 +52,13 @@ class TranslationServiceTest extends TestCase
             [new Translation('Welcome, :name', '')],
             [new Translation('Trip to :planet, check-in opens :time', '')],
             [new Translation('Check offers to :planet', '')],
+            [new Translation('Translations should also work with double quotes.', '')],
+            [new Translation('Shouldn\\\'t escaped quotes within strings also be correctly added?', '')],
+            [new Translation('Same goes for \"double quotes\".', '')],
         ];
 
         $this->repository
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(6))
             ->method('save')
             ->withConsecutive(...$translations);
 

--- a/tests/integration.php
+++ b/tests/integration.php
@@ -12,6 +12,9 @@ $expected = trim(json_encode([
     'Welcome, :name' => '',
     'Trip to :planet, check-in opens :time' => '',
     'Check offers to :planet' => '',
+    'Translations should also work with double quotes.' => '',
+    'Shouldn\\\'t escaped quotes within strings also be correctly added?' => '',
+    'Same goes for \"double quotes\".' => '',
 ], JSON_PRETTY_PRINT));
 
 $received = trim(file_get_contents("resources/lang/pt-br.json"));


### PR DESCRIPTION
This fixes issue #4.

Also added proper support for double quoted strings, currently all double quotes are converted to single quotes, so if you had a string `"like 'this'"`, for example, it would not work.
