### PR TITLE
Various improvements

### DIFF
--- a/src/Infra/LaravelJsonTranslationRepository.php
+++ b/src/Infra/LaravelJsonTranslationRepository.php
@@ -105,7 +105,7 @@ class LaravelJsonTranslationRepository implements TranslationRepository
     {
         file_put_contents(
             $this->getFileNameForLanguage($language),
-            json_encode($this->fileCache[$language], JSON_PRETTY_PRINT)
+            json_encode($this->fileCache[$language], JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE)
         );
     }
 }

--- a/src/Translator/TranslationScanner.php
+++ b/src/Translator/TranslationScanner.php
@@ -54,14 +54,12 @@ class TranslationScanner
      */
     private function getKeysFromFunction(string $functionName, string $content): array
     {
-        preg_match_all("#{$functionName}\((.*?)\)#", $content, $matches);
+        preg_match_all("#{$functionName} *\( *(['\"])((?:\\\\\\1|.)*?)\\1#", $content, $matches);
 
-        $matches = $matches[1] ?? [];
+        $matches = $matches[2] ?? [];
 
         return array_reduce($matches, function (array $keys, string $match) {
-            preg_match("#(['\"])((?:\\\\\\1|.)*?)\\1#", $match, $matchKey);
-
-            $key = str_replace("\\'", "'", $matchKey[2] ?? '');
+            $key = str_replace(["\\'", '\\"'], ["'", '"'], $match ?? '');
 
             return $key ?
                 array_merge($keys, [$key => new Translation($key, '')]) :

--- a/src/Translator/TranslationScanner.php
+++ b/src/Translator/TranslationScanner.php
@@ -59,7 +59,9 @@ class TranslationScanner
         $matches = $matches[1] ?? [];
 
         return array_reduce($matches, function (array $keys, string $match) {
-            eval("\$key = $match;");
+            $quote = $match[0];
+            $match = trim($match, $quote);
+            $key = ($quote === '"') ? stripcslashes($match) : str_replace("\\'", "'", $match);
 
             return $key ?
                 array_merge($keys, [$key => new Translation($key, '')]) :

--- a/src/Translator/TranslationScanner.php
+++ b/src/Translator/TranslationScanner.php
@@ -61,7 +61,7 @@ class TranslationScanner
         return array_reduce($matches, function (array $keys, string $match) {
             preg_match("#(['\"])((?:\\\\\\1|.)*?)\\1#", $match, $matchKey);
 
-            $key = $matchKey[2] ?? '';
+            $key = str_replace("\\'", "'", $matchKey[2] ?? '');
 
             return $key ?
                 array_merge($keys, [$key => new Translation($key, '')]) :

--- a/src/Translator/TranslationScanner.php
+++ b/src/Translator/TranslationScanner.php
@@ -61,7 +61,7 @@ class TranslationScanner
         return array_reduce($matches, function (array $keys, string $match) {
             $quote = $match[0];
             $match = trim($match, $quote);
-            $key = ($quote === '"') ? stripcslashes($match) : str_replace("\\'", "'", $match);
+            $key = ($quote === '"') ? stripcslashes($match) : str_replace(["\\'", "\\\\"], ["'", "\\"], $match);
 
             return $key ?
                 array_merge($keys, [$key => new Translation($key, '')]) :

--- a/src/Translator/TranslationScanner.php
+++ b/src/Translator/TranslationScanner.php
@@ -54,12 +54,12 @@ class TranslationScanner
      */
     private function getKeysFromFunction(string $functionName, string $content): array
     {
-        preg_match_all("#{$functionName} *\( *(['\"])((?:\\\\\\1|.)*?)\\1#", $content, $matches);
+        preg_match_all("#{$functionName} *\( *((['\"])((?:\\\\\\2|.)*?)\\2)#", $content, $matches);
 
-        $matches = $matches[2] ?? [];
+        $matches = $matches[1] ?? [];
 
         return array_reduce($matches, function (array $keys, string $match) {
-            $key = str_replace(["\\'", '\\"'], ["'", '"'], $match ?? '');
+            eval("\$key = $match;");
 
             return $key ?
                 array_merge($keys, [$key => new Translation($key, '')]) :

--- a/tests/Fixtures/App/View/index.blade.php
+++ b/tests/Fixtures/App/View/index.blade.php
@@ -26,5 +26,9 @@
         <div>
             {{ __("Same goes for \"double quotes\".") }}
         </div>
+
+        <div>
+            {{ __('String using (parentheses).') }}
+        </div>
     </body>
 </html>

--- a/tests/Fixtures/App/View/index.blade.php
+++ b/tests/Fixtures/App/View/index.blade.php
@@ -30,5 +30,9 @@
         <div>
             {{ __('String using (parentheses).') }}
         </div>
+
+        <div>
+            {{ __("Double quoted string using \"double quotes\", and C-style escape sequences.\n\t\\") }}
+        </div>
     </body>
 </html>

--- a/tests/Unit/Translator/TranslationScannerTest.php
+++ b/tests/Unit/Translator/TranslationScannerTest.php
@@ -77,7 +77,8 @@ class TranslationScannerTest extends TestCase
                     'Shouldn\'t escaped quotes within strings also be correctly added?',
                     ''
                 ),
-                'Same goes for \"double quotes\".' => new Translation('Same goes for \"double quotes\".', ''),
+                'Same goes for "double quotes".' => new Translation('Same goes for "double quotes".', ''),
+                'String using (parentheses).' => new Translation('String using (parentheses).', ''),
             ],
             $translations
         );
@@ -102,7 +103,8 @@ class TranslationScannerTest extends TestCase
                     'Shouldn\'t escaped quotes within strings also be correctly added?',
                     ''
                 ),
-                'Same goes for \"double quotes\".' => new Translation('Same goes for \"double quotes\".', ''),
+                'Same goes for "double quotes".' => new Translation('Same goes for "double quotes".', ''),
+                'String using (parentheses).' => new Translation('String using (parentheses).', ''),
                 'Underscore: :foo, :bar' => new Translation('Underscore: :foo, :bar', ''),
                 'Lang: :foo, :bar' => new Translation('Lang: :foo, :bar', ''),
             ],

--- a/tests/Unit/Translator/TranslationScannerTest.php
+++ b/tests/Unit/Translator/TranslationScannerTest.php
@@ -79,6 +79,10 @@ class TranslationScannerTest extends TestCase
                 ),
                 'Same goes for "double quotes".' => new Translation('Same goes for "double quotes".', ''),
                 'String using (parentheses).' => new Translation('String using (parentheses).', ''),
+                "Double quoted string using \"double quotes\", and C-style escape sequences.\n\t\\" => new Translation(
+                    "Double quoted string using \"double quotes\", and C-style escape sequences.\n\t\\",
+                    ''
+                ),
             ],
             $translations
         );
@@ -107,6 +111,10 @@ class TranslationScannerTest extends TestCase
                 'String using (parentheses).' => new Translation('String using (parentheses).', ''),
                 'Underscore: :foo, :bar' => new Translation('Underscore: :foo, :bar', ''),
                 'Lang: :foo, :bar' => new Translation('Lang: :foo, :bar', ''),
+                "Double quoted string using \"double quotes\", and C-style escape sequences.\n\t\\" => new Translation(
+                    "Double quoted string using \"double quotes\", and C-style escape sequences.\n\t\\",
+                    ''
+                ),
             ],
             $translations
         );

--- a/tests/Unit/Translator/TranslationScannerTest.php
+++ b/tests/Unit/Translator/TranslationScannerTest.php
@@ -73,8 +73,8 @@ class TranslationScannerTest extends TestCase
                     'Translations should also work with double quotes.',
                     ''
                 ),
-                'Shouldn\\\'t escaped quotes within strings also be correctly added?' => new Translation(
-                    'Shouldn\\\'t escaped quotes within strings also be correctly added?',
+                'Shouldn\'t escaped quotes within strings also be correctly added?' => new Translation(
+                    'Shouldn\'t escaped quotes within strings also be correctly added?',
                     ''
                 ),
                 'Same goes for \"double quotes\".' => new Translation('Same goes for \"double quotes\".', ''),
@@ -98,8 +98,8 @@ class TranslationScannerTest extends TestCase
                     'Translations should also work with double quotes.',
                     ''
                 ),
-                'Shouldn\\\'t escaped quotes within strings also be correctly added?' => new Translation(
-                    'Shouldn\\\'t escaped quotes within strings also be correctly added?',
+                'Shouldn\'t escaped quotes within strings also be correctly added?' => new Translation(
+                    'Shouldn\'t escaped quotes within strings also be correctly added?',
                     ''
                 ),
                 'Same goes for \"double quotes\".' => new Translation('Same goes for \"double quotes\".', ''),

--- a/tests/Unit/Translator/TranslationServiceTest.php
+++ b/tests/Unit/Translator/TranslationServiceTest.php
@@ -56,10 +56,11 @@ class TranslationServiceTest extends TestCase
             [new Translation('Shouldn\'t escaped quotes within strings also be correctly added?', '')],
             [new Translation('Same goes for "double quotes".', '')],
             [new Translation('String using (parentheses).', '')],
+            [new Translation("Double quoted string using \"double quotes\", and C-style escape sequences.\n\t\\", '')],
         ];
 
         $this->repository
-            ->expects($this->exactly(7))
+            ->expects($this->exactly(8))
             ->method('save')
             ->withConsecutive(...$translations);
 

--- a/tests/Unit/Translator/TranslationServiceTest.php
+++ b/tests/Unit/Translator/TranslationServiceTest.php
@@ -53,7 +53,7 @@ class TranslationServiceTest extends TestCase
             [new Translation('Trip to :planet, check-in opens :time', '')],
             [new Translation('Check offers to :planet', '')],
             [new Translation('Translations should also work with double quotes.', '')],
-            [new Translation('Shouldn\\\'t escaped quotes within strings also be correctly added?', '')],
+            [new Translation('Shouldn\'t escaped quotes within strings also be correctly added?', '')],
             [new Translation('Same goes for \"double quotes\".', '')],
         ];
 

--- a/tests/Unit/Translator/TranslationServiceTest.php
+++ b/tests/Unit/Translator/TranslationServiceTest.php
@@ -54,11 +54,12 @@ class TranslationServiceTest extends TestCase
             [new Translation('Check offers to :planet', '')],
             [new Translation('Translations should also work with double quotes.', '')],
             [new Translation('Shouldn\'t escaped quotes within strings also be correctly added?', '')],
-            [new Translation('Same goes for \"double quotes\".', '')],
+            [new Translation('Same goes for "double quotes".', '')],
+            [new Translation('String using (parentheses).', '')],
         ];
 
         $this->repository
-            ->expects($this->exactly(6))
+            ->expects($this->exactly(7))
             ->method('save')
             ->withConsecutive(...$translations);
 

--- a/tests/integration.php
+++ b/tests/integration.php
@@ -16,6 +16,7 @@ $expected = trim(json_encode([
     'Shouldn\'t escaped quotes within strings also be correctly added?' => '',
     'Same goes for "double quotes".' => '',
     'String using (parentheses).' => '',
+    "Double quoted string using \"double quotes\", and C-style escape sequences.\n\t\\" => '',
 ], JSON_PRETTY_PRINT));
 
 $received = trim(file_get_contents("resources/lang/pt-br.json"));

--- a/tests/integration.php
+++ b/tests/integration.php
@@ -13,7 +13,7 @@ $expected = trim(json_encode([
     'Trip to :planet, check-in opens :time' => '',
     'Check offers to :planet' => '',
     'Translations should also work with double quotes.' => '',
-    'Shouldn\\\'t escaped quotes within strings also be correctly added?' => '',
+    'Shouldn\'t escaped quotes within strings also be correctly added?' => '',
     'Same goes for \"double quotes\".' => '',
 ], JSON_PRETTY_PRINT));
 

--- a/tests/integration.php
+++ b/tests/integration.php
@@ -14,7 +14,8 @@ $expected = trim(json_encode([
     'Check offers to :planet' => '',
     'Translations should also work with double quotes.' => '',
     'Shouldn\'t escaped quotes within strings also be correctly added?' => '',
-    'Same goes for \"double quotes\".' => '',
+    'Same goes for "double quotes".' => '',
+    'String using (parentheses).' => '',
 ], JSON_PRETTY_PRINT));
 
 $received = trim(file_get_contents("resources/lang/pt-br.json"));


### PR DESCRIPTION
I have made a few more improvements to the code:

1. Made sure all translatable strings in the code are evaluated the same way PHP evaluates them when running the code. That includes all sorts of escape sequences, which may or may not differ based on whether you're using single or double quotes.   _Edit:_ Sadly, this caused Codacy to complain over the use of the `eval` function, but doing this in any other way would likely require a serious overhaul of the way the strings are parsed.   _Edit 2:_ Avoided using `eval` by using `stripcslashes` for double quoted strings, and simply replacing escaped single quotes and backslashes otherwise, which should mimic the behavior of PHP exactly.
2. Previously, when a string included a closing parenthesis, the parser would count it as the ending parenthesis of the translation function, which would break the detection of the string (usually resulting in a truncated result, or even no detection at all in certain cases). I refactored the parsing function to account for such cases properly.
3. Added `JSON_UNESCAPED_UNICODE` flag to the `json_encode()` function call when writing the translations file. This avoids ugly escape sequences in the results as well as the case where existing keys were not found due to previously escaped unicode characters being present in the JSON file but unescaped in the actual string used in the translation function call.
4. A minor one, but spaces before and after the opening parentheses of the translation function calls are also now supported.